### PR TITLE
setup appDir variable. allowing to override this

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 (new Dotenv())->load(__DIR__ . '/.env');
 
 $config = [
+    'appDir' => __DIR__,
     'env' => $_SERVER['APP_ENV'] ?? 'dev',
 ];
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -30,7 +30,7 @@ class Application extends BaseApplication
         $this->register(new ServiceProvider\CommandProvider());
         $this->register(new MonologServiceProvider(), [
             'monolog.name' => self::NAME,
-            'monolog.logfile' => dirname(__DIR__) . "/var/log/{$this['env']}.log",
+            'monolog.logfile' => "{$this['appDir']}/var/log/{$this['env']}.log",
             'monolog.use_error_handler' => true,
         ]);
     }


### PR DESCRIPTION
this allows you to create your own bootstrap:

```php
<?php

use SlackUnfurl\Application;
use Symfony\Component\Dotenv\Dotenv;

require_once __DIR__ . '/vendor/autoload.php';

(new Dotenv())->load(__DIR__ . '/.env');

$config = [
    'appDir' => __DIR__,
    'env' => $_SERVER['APP_ENV'] ?? 'dev',
];

$app = new Application($config);

$app->register(new \Eventum\SlackUnfurl\ServiceProvider\EventumUnfurlServiceProvider());
$app->register(new \GitlabSlackUnfurl\ServiceProvider\GitlabUnfurlServiceProvider());
$app->register(new \JiraSlackUnfurl\ServiceProvider\JiraUnfurlServiceProvider());

return $app;
```