### PR TITLE
Add path prefix configuration support

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,9 +1,15 @@
 # Env variables setup
 # copy env.example to .env to configure
 
+# Path prefix under what to expose app.
+# Example: /slack-unfurl/
+APP_PREFIX=/
+
 # Request URL Configuration & Verification
 # https://api.slack.com/events-api#request_url_configuration__amp__verification
 SLACK_VERIFICATION_TOKEN=xxx
 
 # OAuth2 token for Web API method chat.unfurl
 SLACK_API_TOKEN=xoxp-xxx
+
+# EOF

--- a/src/Application.php
+++ b/src/Application.php
@@ -37,10 +37,10 @@ class Application extends BaseApplication
 
     private function configureRoutes()
     {
-        $this->post('/', function (Request $request) {
+        $this->post($this['unfurl.app_prefix'], function (Request $request) {
             return $this[UnfurlController::class]($request);
         });
-        $this->get('/', function (Request $request) {
+        $this->get($this['unfurl.app_prefix'], function (Request $request) {
             return $this[InfoController::class]($request);
         });
     }

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -18,6 +18,7 @@ class ServiceProvider implements ServiceProviderInterface
     {
         $app['unfurl.slack_api_token'] = getenv('SLACK_API_TOKEN');
         $app['unfurl.slack_verification_token'] = getenv('SLACK_VERIFICATION_TOKEN');
+        $app['unfurl.app_prefix'] = getenv('APP_PREFIX') ?: '/';
 
         $app[SlackClient::class] = function ($app) {
             return new SlackClient($app['unfurl.slack_api_token']);

--- a/web/index.php
+++ b/web/index.php
@@ -1,6 +1,4 @@
 <?php
 
-ini_set('display_errors', 0);
-
 $app = require __DIR__ . '/../bootstrap.php';
 $app->run();


### PR DESCRIPTION
This allows app run under subpaths:

- `https://example.org/slack-unfurl/`