### PR TITLE
Specify platform version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
     "license": "MIT",
     "type": "project",
     "config": {
+        "platform": {
+            "php": "7.1.3"
+        },
         "process-timeout": 0,
         "sort-packages": true
     },


### PR DESCRIPTION
This is the minimum version the dependencies are solved for.
Useful for building stable composer.lock